### PR TITLE
Assassin's Creed Mirage.asl

### DIFF
--- a/Assassin's Creed Mirage.asl
+++ b/Assassin's Creed Mirage.asl
@@ -18,30 +18,25 @@ init
 
     switch (md5)
     {
-        case "A4D96EBBFF2D861198F1D70191778246":
-            version = "Release";
-            break;
-        case "E1EC754BE4BBDA435AF11BB329FFBB3B";
+        case "E1EC754BE4BBDA435AF11BB329FFBB3B":
             version = "Current";
             break;
         default:
-            version = "Current";
+            version = "N/A";
             break;
     }
 }
 
 isLoading
 {
-	if(version == "Current")
+    if (current.loading == 1 && old.loading == 0)
     {
-        if (current.loading == 1 && old.loading == 0)
-        {
-            return true;
-        }
-        else{
-            return false;
-        }
+        return true;
+    } else
+    {
+        return false;
     }
+
 	
 }
 


### PR DESCRIPTION
Fixed a syntax error for switching also remove the if version == current sense that was only there so if someone somehow got the original version of mirage it would still work. Might be able to add a auto split to mirage but depends if i can find anything. Made default be N/A so people can be on the right version.